### PR TITLE
add (failing) tests for unauthorized ec2 crud

### DIFF
--- a/tests/backend_sql.conf
+++ b/tests/backend_sql.conf
@@ -9,4 +9,4 @@ pool_timeout = 200
 driver = keystone.identity.backends.sql.Identity
 
 [ec2]
-driver = keystone.contrib.ec2.backends.SqlEc2
+driver = keystone.contrib.ec2.backends.sql.Ec2

--- a/tests/backend_sql.conf
+++ b/tests/backend_sql.conf
@@ -7,3 +7,6 @@ pool_timeout = 200
 
 [identity]
 driver = keystone.identity.backends.sql.Identity
+
+[ec2]
+driver = keystone.contrib.ec2.backends.SqlEc2

--- a/tests/default_fixtures.py
+++ b/tests/default_fixtures.py
@@ -5,6 +5,7 @@ TENANTS = [
 
 USERS = [
     {'id': 'foo', 'name': 'FOO', 'password': 'foo2', 'tenants': ['bar',]},
+    {'id': 'boo', 'name': 'BOO', 'password': 'boo2', 'tenants': ['baz',]},
     ]
 
 METADATA = [

--- a/tests/default_fixtures.py
+++ b/tests/default_fixtures.py
@@ -10,6 +10,7 @@ USERS = [
 
 METADATA = [
     {'user_id': 'foo', 'tenant_id': 'bar', 'extra': 'extra'},
+    {'user_id': 'boo', 'tenant_id': 'baz', 'extra': 'extra'},
     ]
 
 ROLES = [

--- a/tests/default_fixtures.py
+++ b/tests/default_fixtures.py
@@ -5,12 +5,12 @@ TENANTS = [
 
 USERS = [
     {'id': 'foo', 'name': 'FOO', 'password': 'foo2', 'tenants': ['bar',]},
-    {'id': 'boo', 'name': 'BOO', 'password': 'boo2', 'tenants': ['baz',]},
+    {'id': 'two', 'name': 'TWO', 'password': 'two2', 'tenants': ['baz',]},
     ]
 
 METADATA = [
     {'user_id': 'foo', 'tenant_id': 'bar', 'extra': 'extra'},
-    {'user_id': 'boo', 'tenant_id': 'baz', 'extra': 'extra'},
+    {'user_id': 'two', 'tenant_id': 'baz', 'extra': 'extra'},
     ]
 
 ROLES = [

--- a/tests/test_keystoneclient.py
+++ b/tests/test_keystoneclient.py
@@ -263,14 +263,14 @@ class KcMasterTestCase(CompatTestCase):
         creds = client.ec2.list(self.user_foo['id'])
         self.assertEquals(creds, [])
 
-    def test_ec2_credentials_scoping_list(self):
+    def test_ec2_credentials_list_unauthorized_user(self):
         from keystoneclient import exceptions as client_exceptions
 
         boo = self.get_client('BOO')
         self.assertRaises(client_exceptions.Unauthorized, boo.ec2.list,
                           self.user_foo['id'])
 
-    def test_ec2_credentials_scoping_get(self):
+    def test_ec2_credentials_get_unauthorized_user(self):
         from keystoneclient import exceptions as client_exceptions
 
         foo = self.get_client()
@@ -282,7 +282,7 @@ class KcMasterTestCase(CompatTestCase):
         
         foo.ec2.delete(self.user_foo['id'], cred.access)
 
-    def test_ec2_credentials_scoping_delete(self):
+    def test_ec2_credentials_delete_unauthorized_user(self):
         from keystoneclient import exceptions as client_exceptions
 
         foo = self.get_client()

--- a/tests/test_keystoneclient.py
+++ b/tests/test_keystoneclient.py
@@ -263,12 +263,36 @@ class KcMasterTestCase(CompatTestCase):
         creds = client.ec2.list(self.user_foo['id'])
         self.assertEquals(creds, [])
 
-    def test_ec2_credentials_scoping(self):
+    def test_ec2_credentials_scoping_list(self):
         from keystoneclient import exceptions as client_exceptions
 
         boo = self.get_client('BOO')
         self.assertRaises(client_exceptions.Unauthorized, boo.ec2.list,
                           self.user_foo['id'])
+
+    def test_ec2_credentials_scoping_get(self):
+        from keystoneclient import exceptions as client_exceptions
+
+        foo = self.get_client()
+        cred = foo.ec2.create(self.user_foo['id'], self.tenant_bar['id'])
+
+        boo = self.get_client('BOO')
+        self.assertRaises(client_exceptions.Unauthorized, boo.ec2.get,
+                          self.user_foo['id'], cred.access)
+        
+        foo.ec2.delete(self.user_foo['id'], cred.access)
+
+    def test_ec2_credentials_scoping_delete(self):
+        from keystoneclient import exceptions as client_exceptions
+
+        foo = self.get_client()
+        cred = foo.ec2.create(self.user_foo['id'], self.tenant_bar['id'])
+
+        boo = self.get_client('BOO')
+        self.assertRaises(client_exceptions.Unauthorized, boo.ec2.delete,
+                          self.user_foo['id'], cred.access)
+        
+        foo.ec2.delete(self.user_foo['id'], cred.access)
 
     def test_service_create_and_delete(self):
         from keystoneclient import exceptions as client_exceptions

--- a/tests/test_keystoneclient.py
+++ b/tests/test_keystoneclient.py
@@ -65,14 +65,13 @@ class KcMasterTestCase(CompatTestCase):
         CONF(config_files=[test.etcdir('keystone.conf'),
                            test.testsdir('test_overrides.conf')])
 
-    def get_client(self, username='FOO'):
-        users = [u for u in default_fixtures.USERS if u['name'] == username]
-        self.assertEquals(1, len(users))
-        user = users[0]
+    def get_client(self, user_ref=None):
+        if user_ref is None:
+            user_ref = self.user_foo
 
-        return self._client(username=user['name'],
-                            password=user['password'],
-                            tenant_id=user['tenants'][0])
+        return self._client(username=user_ref['name'],
+                            password=user_ref['password'],
+                            tenant_id=user_ref['tenants'][0])
 
     def test_authenticate_tenant_name_and_tenants(self):
         client = self.get_client()
@@ -266,8 +265,8 @@ class KcMasterTestCase(CompatTestCase):
     def test_ec2_credentials_list_unauthorized_user(self):
         from keystoneclient import exceptions as client_exceptions
 
-        boo = self.get_client('BOO')
-        self.assertRaises(client_exceptions.Unauthorized, boo.ec2.list,
+        two = self.get_client(self.user_two)
+        self.assertRaises(client_exceptions.Unauthorized, two.ec2.list,
                           self.user_foo['id'])
 
     def test_ec2_credentials_get_unauthorized_user(self):
@@ -276,10 +275,10 @@ class KcMasterTestCase(CompatTestCase):
         foo = self.get_client()
         cred = foo.ec2.create(self.user_foo['id'], self.tenant_bar['id'])
 
-        boo = self.get_client('BOO')
-        self.assertRaises(client_exceptions.Unauthorized, boo.ec2.get,
+        two = self.get_client(self.user_two)
+        self.assertRaises(client_exceptions.Unauthorized, two.ec2.get,
                           self.user_foo['id'], cred.access)
-        
+
         foo.ec2.delete(self.user_foo['id'], cred.access)
 
     def test_ec2_credentials_delete_unauthorized_user(self):
@@ -288,8 +287,8 @@ class KcMasterTestCase(CompatTestCase):
         foo = self.get_client()
         cred = foo.ec2.create(self.user_foo['id'], self.tenant_bar['id'])
 
-        boo = self.get_client('BOO')
-        self.assertRaises(client_exceptions.Unauthorized, boo.ec2.delete,
+        two = self.get_client(self.user_two)
+        self.assertRaises(client_exceptions.Unauthorized, two.ec2.delete,
                           self.user_foo['id'], cred.access)
         
         foo.ec2.delete(self.user_foo['id'], cred.access)

--- a/tests/test_keystoneclient.py
+++ b/tests/test_keystoneclient.py
@@ -65,13 +65,19 @@ class KcMasterTestCase(CompatTestCase):
         CONF(config_files=[test.etcdir('keystone.conf'),
                            test.testsdir('test_overrides.conf')])
 
-    def get_client(self, user_ref=None):
+    def get_client(self, user_ref=None, tenant_ref=None):
         if user_ref is None:
             user_ref = self.user_foo
+        if tenant_ref is None:
+            for user in default_fixtures.USERS:
+                if user['id'] == user_ref['id']:
+                    tenant_id = user['tenants'][0]
+        else:
+            tenant_id = tenant_ref['id']
 
         return self._client(username=user_ref['name'],
                             password=user_ref['password'],
-                            tenant_id=user_ref['tenants'][0])
+                            tenant_id=tenant_id)
 
     def test_authenticate_tenant_name_and_tenants(self):
         client = self.get_client()


### PR DESCRIPTION
Currently the test fails with:

AuthorizationFailure: Authorization Failed: Unable to communicate with identity service: Traceback (most recent call last)

It seems to be making the request with:

```
root: DEBUG: {"auth": {"passwordCredentials": {"username": "BOO", "password": "boo2"}, "tenantId": "baz"}}
```

But keystone is blowing up with:

```
File "/Users/jesse/rcb/keystonelight/keystone/service.py", line 587, in authenticate
  for role_id in metadata_ref.get('roles', []):
AttributeError: 'NoneType' object has no attribute 'get'
```
