### PR TITLE
initial stab at requiring adminness

### DIFF
--- a/tests/test_keystoneclient.py
+++ b/tests/test_keystoneclient.py
@@ -372,17 +372,25 @@ class KcMasterTestCase(CompatTestCase):
 
     def test_admin_requires_adminness(self):
         from keystoneclient import exceptions as client_exceptions
-        # FIXME(termie): this should be Unauthorized
+        # FIXME(ja): this should be Unauthorized
         exception = client_exceptions.ClientException
 
         two = self.get_client(self.user_two)  # non-admin user
 
         # USER CRUD
-        self.assertRaises(exception, two.users.list)
-        self.assertRaises(exception, two.users.get, self.user_two['id'])
-        self.assertRaises(exception, two.users.create, name='oops',
-                          password='password', email='oops@test.com')
-        self.assertRaises(exception, two.users.delete, self.user_foo['id'])
+        self.assertRaises(exception,
+                          two.users.list)
+        self.assertRaises(exception,
+                          two.users.get,
+                          user=self.user_two['id'])
+        self.assertRaises(exception,
+                          two.users.create,
+                          name='oops',
+                          password='password',
+                          email='oops@test.com')
+        self.assertRaises(exception,
+                          two.users.delete,
+                          user=self.user_foo['id'])
 
         # TENANT CRUD
         # NOTE(ja): tenants.list is different since /tenants fulfills the
@@ -393,17 +401,30 @@ class KcMasterTestCase(CompatTestCase):
         tenants = two.tenants.list()
         self.assertTrue(len(tenants) == 1)
         self.assertTrue(tenants[0].id == self.tenant_baz['id'])
-        self.assertRaises(exception, two.tenants.get, self.tenant_bar['id'])
-        self.assertRaises(exception, two.tenants.create,
-                          tenant_name='oops', description="shouldn't work!",
+        self.assertRaises(exception,
+                          two.tenants.get,
+                          tenant_id=self.tenant_bar['id'])
+        self.assertRaises(exception,
+                          two.tenants.create,
+                          tenant_name='oops',
+                          description="shouldn't work!",
                           enabled=True)
-        self.assertRaises(exception, two.tenants.delete, self.tenant_baz['id'])
+        self.assertRaises(exception,
+                          two.tenants.delete,
+                          tenant=self.tenant_baz['id'])
 
         # ROLE CRUD
-        self.assertRaises(exception, two.roles.get, role='keystone_admin')
-        self.assertRaises(exception, two.roles.list)
-        self.assertRaises(exception, two.roles.create, name='oops')
-        self.assertRaises(exception, two.roles.delete, 'keystone_admin')
+        self.assertRaises(exception,
+                          two.roles.get,
+                          role='keystone_admin')
+        self.assertRaises(exception,
+                          two.roles.list)
+        self.assertRaises(exception,
+                          two.roles.create,
+                          name='oops')
+        self.assertRaises(exception,
+                          two.roles.delete,
+                          role='keystone_admin')
 
         # TODO(ja): MEMBERSHIP CRUD
         # TODO(ja): determine what else todo

--- a/tests/test_keystoneclient.py
+++ b/tests/test_keystoneclient.py
@@ -403,7 +403,7 @@ class KcMasterTestCase(CompatTestCase):
         self.assertRaises(exception, two.roles.get, role='keystone_admin')
         self.assertRaises(exception, two.roles.list)
         self.assertRaises(exception, two.roles.create, name='oops')
-        self.assertRaises(exception, two.roles.delete, name='keystone_admin')
+        self.assertRaises(exception, two.roles.delete, 'keystone_admin')
 
         # TODO(ja): MEMBERSHIP CRUD
         # TODO(ja): determine what else todo


### PR DESCRIPTION
haven't hit everything but I'm having to catch:

```
client_exceptions.ClientException
```

instead of:

```
client_exceptions.Unauthorized
```

Since right now these seem to throw 500s

Also not sure what to do about the CLI version of these tests since it throws:

```
ERROR: test_admin_requires_adminness (test_cli.CliMasterTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/jesse/rcb/keystonelight/tests/test_keystoneclient.py", line 382, in test_admin_requires_adminness
    self.assertRaises(exception, two.users.get, self.user_two['id'])
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/unittest/case.py", line 456, in assertRaises
    callableObj(*args, **kwargs)
TypeError: __call__() takes exactly 1 argument (2 given)
```
