### PR TITLE
Binaries conflict with python-keystoneclient

### DIFF
--- a/bin/keystone-server
+++ b/bin/keystone-server
@@ -12,7 +12,7 @@ possible_topdir = os.path.normpath(os.path.join(os.path.abspath(sys.argv[0]),
                                    os.pardir,
                                    os.pardir))
 if os.path.exists(os.path.join(possible_topdir,
-                               'keystone',
+                               'keystone-server',
                                '__init__.py')):
     sys.path.insert(0, possible_topdir)
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(name='keystone',
       author_email='openstack@lists.launchpad.net',
       url='http://www.openstack.org',
       packages=find_packages(exclude=['test', 'bin']),
-      scripts=['bin/keystone', 'bin/keystone-manage'],
+      scripts=['bin/keystone-server', 'bin/keystone-manage'],
       zip_safe=False,
       install_requires=['setuptools', 'python-keystoneclient'],
       )


### PR DESCRIPTION
keystonelight and python-keystoneclient binaries conflict, so call bin/keystone bin/keystone-server.

Signed-off-by: Chuck Short chuck.short@canonical.com
